### PR TITLE
Update prodigy-segment for prodigy==1.14.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a Prodigy plugin for recipes that involve Metas [Segmen
 You can install this plugin via `pip`. 
 
 ```
-pip install "prodigy-ann @ git+https://github.com/explosion/prodigy-segment"
+pip install "prodigy-segment @ git+https://github.com/explosion/prodigy-segment"
 ```
 
 To learn more about this plugin, you can check the [Prodigy docs](https://prodi.gy/docs/plugins/#segment).

--- a/prodigy_segment/__init__.py
+++ b/prodigy_segment/__init__.py
@@ -139,7 +139,7 @@ def encode_image(example: TaskType, cache: Cache, predictor: SamPredictor):
     """Encodes the image while also checking the cache."""
     if example['path'] not in cache:
         tic = time.time()
-        base64_img = get_base64_string(example)
+        base64_img = get_base64_string(example["image"])
         pil_image = Image.open(BytesIO(base64.b64decode(base64_img))).convert("RGBA")
         # This is an expensive compute, prefer to do only once.
         predictor.set_image(np.array(pil_image.convert("RGB")))

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
 [options.entry_points]
 prodigy_recipes =
     segment.image.manual = prodigy_segment:segment_image_manual
-    segment.cache = prodigy_segment:segment_cache
+    segment.cache = prodigy_segment:segment_fill_cache
 
 [bdist_wheel]
 universal = true


### PR DESCRIPTION
- Update the README to point to `prodigy-segment` rather than `prodigy-ann`
- Update entrypoint to `segment_fill_cache` to reflect `prodigy==1.14.12`
- The image to label was not being passed through to encode, resulting in the following exception
```
  File "/usr/local/lib/python3.11/site-packages/prodigy_segment/__init__.py", line 142, in encode_image
    base64_img = get_base64_string(example)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/prodigy_segment/__init__.py", line 134, in get_base64_string
    str_idx = img_str.find("base64,") + 7
              ^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'find'
```