### PR TITLE
Update setup.cfg

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+
       - name: Check out Prodigy
         uses: actions/checkout@v4
         with:
@@ -22,7 +23,7 @@ jobs:
           ref: v1.14.11
           path: ./prodigy
           ssh-key: ${{ secrets.GHA_PRODIGY_READ }}
-          
+
       - name: Install prodigy
         run: |
           ls -la

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,22 +15,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-
-      - name: Check out Prodigy
-        uses: actions/checkout@v3
-        with:
-          repository: explosion/prodigy
-          ref: v1.14.11
-          path: ./prodigy
-          ssh-key: ${{ secrets.GHA_PRODIGY_READ }}
-
-      - name: Install prodigy
+      - name: Install Prodigy from private repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA_PRODIGY_READ }} # Use the secret here
         run: |
-          ls -la
-          pip install ./prodigy
-          python -m prodigy --help
-
-      - name: Install dependencies
+          export GIT_LFS_SKIP_SMUDGE=1 
+          pip install --upgrade pip
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/explosion/prodigy.git
+          cd prodigy
+          pip install setuptools wheel
+          pip install -e .
+          cd ..
+      - name: Install additional dependencies
         run: |
           pip install --upgrade pip
           pip install -e .
@@ -45,3 +41,5 @@ jobs:
         if: always()
         shell: bash
         run: python -m pytest tests
+      
+     

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Check out Prodigy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: explosion/prodigy
           ref: v1.14.11

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,18 +15,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Install Prodigy from private repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHA_PRODIGY_READ }} # Use the secret here
+      - name: Check out Prodigy
+        uses: actions/checkout@v3
+        with:
+          repository: explosion/prodigy
+          ref: v1.14.11
+          path: ./prodigy
+          ssh-key: ${{ secrets.GHA_PRODIGY_READ }}
+          
+      - name: Install prodigy
         run: |
-          export GIT_LFS_SKIP_SMUDGE=1 
-          pip install --upgrade pip
-          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/explosion/prodigy.git
-          cd prodigy
-          pip install setuptools wheel
-          pip install -e .
-          cd ..
-      - name: Install additional dependencies
+          ls -la
+          pip install ./prodigy
+          python -m prodigy --help
+
+      - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install -e .
@@ -41,5 +44,3 @@ jobs:
         if: always()
         shell: bash
         run: python -m pytest tests
-      
-     

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a Prodigy plugin for recipes that involve Metas [Segmen
 You can install this plugin via `pip`. 
 
 ```
-pip install "prodigy-ann @ git+https://github.com/explosion/prodigy-segment"
+pip install "prodigy-segment @ git+https://github.com/explosion/prodigy-segment"
 ```
 
 To learn more about this plugin, you can check the [Prodigy docs](https://prodi.gy/docs/plugins/#segment).

--- a/prodigy_segment/__init__.py
+++ b/prodigy_segment/__init__.py
@@ -183,7 +183,7 @@ def segment_fill_cache(source: SourceType, checkpoint: Path, model_type: str = "
     dataset=Arg(help="Dataset to save annotations to"),
     source=Arg(help="Data to annotate (directory of images, file path or '-' to read from standard input)"),
     checkpoint=Arg(help="Path to model checkpoint"),
-    labels=Arg("--label", "-l", help="Comma-separated label(s) to annotate or text file with one label per line"),
+    labels=Arg("--labels", "-l", help="Comma-separated label(s) to annotate or text file with one label per line"),
     loader=Arg("--loader", "-lo", help="Loader if source is not directory of images"),
     exclude=Arg("--exclude", "-e", help="Comma-separated list of dataset IDs whose annotations to exclude"),
     darken=Arg("--darken", "-D", help="Darken image to make boxes stand out more"),

--- a/prodigy_segment/__init__.py
+++ b/prodigy_segment/__init__.py
@@ -15,6 +15,7 @@ from prodigy.types import LabelsType, SourceType, TaskType
 from prodigy.util import log, msg
 from prodigy_segment.segment_anything import sam_model_registry, SamPredictor
 
+from typing import Dict
 
 HTML = """
 <link
@@ -125,12 +126,13 @@ def calculate_masks(box_coordinates: List, predictor: SamPredictor, pil_image: I
     return masks
 
 
-def get_base64_string(img_str: str):
+def get_base64_string(img_dict: Dict[str, str]):
     # This looks hacky at first glance, but the reasoning here is that the schema
     # per https://en.wikipedia.org/wiki/Data_URI_scheme#Syntax looks like this:
     # data:[<media type>][;charset=<character set>][;base64],<data>
     # The encoding will always end with base64, so that's the easy place to cut. 
-    # Otherwise we risk assuming a media type or characterset.
+    # Otherwise we risk assuming a media type or characterset.    
+    img_str = img_dict["image"]
     str_idx = img_str.find("base64,") + 7
     return img_str[str_idx:]
 

--- a/prodigy_segment/__init__.py
+++ b/prodigy_segment/__init__.py
@@ -15,7 +15,7 @@ from prodigy.types import LabelsType, SourceType, TaskType
 from prodigy.util import log, msg
 from prodigy_segment.segment_anything import sam_model_registry, SamPredictor
 
-from typing import Dict
+from typing import Dict, Union
 
 HTML = """
 <link
@@ -126,13 +126,13 @@ def calculate_masks(box_coordinates: List, predictor: SamPredictor, pil_image: I
     return masks
 
 
-def get_base64_string(img_dict: Dict[str, str]):
+def get_base64_string(img: Union[Dict[str, str], str]):
     # This looks hacky at first glance, but the reasoning here is that the schema
     # per https://en.wikipedia.org/wiki/Data_URI_scheme#Syntax looks like this:
     # data:[<media type>][;charset=<character set>][;base64],<data>
     # The encoding will always end with base64, so that's the easy place to cut. 
-    # Otherwise we risk assuming a media type or characterset.    
-    img_str = img_dict["image"]
+    # Otherwise we risk assuming a media type or characterset.        
+    img_str = img["image"] if isinstance(img, dict) else img
     str_idx = img_str.find("base64,") + 7
     return img_str[str_idx:]
 

--- a/prodigy_segment/__init__.py
+++ b/prodigy_segment/__init__.py
@@ -183,7 +183,7 @@ def segment_fill_cache(source: SourceType, checkpoint: Path, model_type: str = "
     dataset=Arg(help="Dataset to save annotations to"),
     source=Arg(help="Data to annotate (directory of images, file path or '-' to read from standard input)"),
     checkpoint=Arg(help="Path to model checkpoint"),
-    label=Arg("--label", "-l", help="Comma-separated label(s) to annotate or text file with one label per line"),
+    labels=Arg("--label", "-l", help="Comma-separated label(s) to annotate or text file with one label per line"),
     loader=Arg("--loader", "-lo", help="Loader if source is not directory of images"),
     exclude=Arg("--exclude", "-e", help="Comma-separated list of dataset IDs whose annotations to exclude"),
     darken=Arg("--darken", "-D", help="Darken image to make boxes stand out more"),
@@ -198,7 +198,7 @@ def segment_image_manual(
     dataset: str,
     source: SourceType,
     checkpoint: Path,
-    label: LabelsType,
+    labels: LabelsType,
     loader: str = "images",
     exclude: List[str] = [],
     darken: bool = False,
@@ -239,7 +239,7 @@ def segment_image_manual(
     colors = ["#00ffff", "#ff00ff", "#00ff7f", "#ff6347", "#00bfff",
               "#ffa500", "#ff69b4", "#7fffd4", "#ffd700", "#ffdab9", "#adff2f", 
               "#d2b48c", "#dcdcdc", "#ffff00", ]
-    label_2_color = {lab: colors[i] for i, lab in enumerate(label)}
+    label_2_color = {lab: colors[i] for i, lab in enumerate(labels)}
 
     def event_hook(ctrl: Controller, *, example: dict):
         nonlocal cache
@@ -290,7 +290,7 @@ def segment_image_manual(
         "before_db": before_db if remove_base64 else before_db_orig_image,
         "exclude": exclude,
         "config": {
-            "labels": label,
+            "labels": labels,
             "blocks": blocks,
             "darken_image": 0.3 if darken else 0,
             "exclude_by": "input",

--- a/prodigy_segment/__init__.py
+++ b/prodigy_segment/__init__.py
@@ -185,7 +185,7 @@ def segment_fill_cache(source: SourceType, checkpoint: Path, model_type: str = "
     dataset=Arg(help="Dataset to save annotations to"),
     source=Arg(help="Data to annotate (directory of images, file path or '-' to read from standard input)"),
     checkpoint=Arg(help="Path to model checkpoint"),
-    labels=Arg("--labels", "-l", help="Comma-separated label(s) to annotate or text file with one label per line"),
+    label=Arg("--label", "-l", help="Comma-separated label(s) to annotate or text file with one label per line"),
     loader=Arg("--loader", "-lo", help="Loader if source is not directory of images"),
     exclude=Arg("--exclude", "-e", help="Comma-separated list of dataset IDs whose annotations to exclude"),
     darken=Arg("--darken", "-D", help="Darken image to make boxes stand out more"),
@@ -200,7 +200,7 @@ def segment_image_manual(
     dataset: str,
     source: SourceType,
     checkpoint: Path,
-    labels: LabelsType,
+    label: LabelsType,
     loader: str = "images",
     exclude: List[str] = [],
     darken: bool = False,
@@ -241,7 +241,7 @@ def segment_image_manual(
     colors = ["#00ffff", "#ff00ff", "#00ff7f", "#ff6347", "#00bfff",
               "#ffa500", "#ff69b4", "#7fffd4", "#ffd700", "#ffdab9", "#adff2f", 
               "#d2b48c", "#dcdcdc", "#ffff00", ]
-    label_2_color = {lab: colors[i] for i, lab in enumerate(labels)}
+    label_2_color = {lab: colors[i] for i, lab in enumerate(label)}
 
     def event_hook(ctrl: Controller, *, example: dict):
         nonlocal cache
@@ -292,7 +292,7 @@ def segment_image_manual(
         "before_db": before_db if remove_base64 else before_db_orig_image,
         "exclude": exclude,
         "config": {
-            "labels": labels,
+            "labels": label,
             "blocks": blocks,
             "darken_image": 0.3 if darken else 0,
             "exclude_by": "input",

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
 [options.entry_points]
 prodigy_recipes =
     segment.image.manual = prodigy_segment:segment_image_manual
-    segment.cache = prodigy_segment:segment_cache
+    segment.cache = prodigy_segment:segment_fill_cache
 
 [bdist_wheel]
 universal = true


### PR DESCRIPTION
This PR:
- updates `setup.cfg` to use the correct entrypoint for segment.cache
- updates README.md to have the correct `pip install prodigy-segment`
- updates  `get_base64_string` as the input is not always a string 

This is prompted by the support forum comment made [here](https://support.prodi.gy/t/incorrect-recipe-name-in-segment-anything-repos-setup-cfg/7156).

TO DO:
- [x] double check prodigy documentation that it is using the correct `labels` flag