### PR TITLE
try updating checkout action

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.10"
 
       - name: Check out Prodigy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: explosion/prodigy
           ref: v1.14.11


### PR DESCRIPTION
Prodigy repo is not being found anymore.
See if upgrading check out fixes it.